### PR TITLE
refactor: migrate from Google Books API to Open Library API

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -72,7 +72,7 @@ Runs both validation and linting.
   - [ ] Book cover image with border
   - [ ] Book title
   - [ ] Author name
-  - [ ] Link to Google Books (opens in new tab)
+  - [ ] Link to Open Library (opens in new tab)
   - [ ] Book description
 - [ ] "Remove book" button clears book data
 - [ ] "Refresh" button reloads book data
@@ -114,13 +114,6 @@ Test in browsers supported by Trello:
 
 ## Security Validation
 
-### API Key Security
-
-1. Check Google Cloud Console:
-   - [ ] API key has HTTP referrer restrictions
-   - [ ] Allowed referrers: `trello.com/*`, `*.trello.com/*`
-   - [ ] API key is restricted to Google Books API only
-
 ### XSS Prevention
 
 - [ ] Book titles with HTML entities display correctly
@@ -140,7 +133,7 @@ Use the [Trello Developer Power-Up](https://github.com/rwjdk/trello-developer-po
 **Solution**: Check console for CORS errors, verify URL in Trello admin
 
 ### Issue: Search not working
-**Solution**: Check API key, verify network requests in DevTools
+**Solution**: Verify Open Library API is accessible, check network requests in DevTools
 
 ### Issue: Book data not persisting
 **Solution**: Check `t.set()` calls return promises, verify data size < 4096 chars

--- a/card-back-section.html
+++ b/card-back-section.html
@@ -96,10 +96,10 @@
               <div class="book-content">
                 <h3 class="u-text-large u-margin-bottom-sm">${bookData.title}</h3>
                 <p class="u-text-small u-quiet u-margin-bottom">by ${bookData.author}</p>
-                <a  href="${bookData.infoLink}" 
-                    target="_blank" 
+                <a  href="${bookData.infoLink}"
+                    target="_blank"
                     class="u-text-small u-quiet u-margin-bottom">
-                  Link to book on Google ${bookData.isbn}</a>
+                  Link to book on Open Library ${bookData.isbn}</a>
                 <div class="u-text-body">
                   ${bookData.summary}
                 </div>

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "trello",
     "glitch",
     "books",
-    "google-books-api"
+    "open-library-api"
   ],
   "license": "MIT"
 }

--- a/search-books.html
+++ b/search-books.html
@@ -68,7 +68,7 @@
       t.card('name').get('name').then(function (fetchedCardName) {
         $('#search-input').val(fetchedCardName).trigger('input');
       });
-      /* 
+      /*
         This script listens for input events on the element with the ID 'search-input'.
         When the input value changes, it checks if the length of the input value (query) is greater than 2 characters.
         If the query length is greater than 2, it makes an AJAX GET request to the Open Library API to search for books matching the query.
@@ -82,42 +82,52 @@
           // Show loading state
           $('#results').html('<p class="message-text">Searching for books...</p>');
 
-          $.getJSON(`https://www.googleapis.com/books/v1/volumes?q=${encodeURIComponent(query)}&key=AIzaSyBnkwx6tm6DCQxC2gSkvI62J0F7Mq0FGzM`)
+          $.getJSON(`https://openlibrary.org/search.json?q=${encodeURIComponent(query)}&limit=20`)
             .done(function (data) {
               // reset the book data store
               bookDataStore = {};
 
-              // Check if items exist in the response
-              if (!data.items || data.items.length === 0) {
+              // Check if docs exist in the response
+              if (!data.docs || data.docs.length === 0) {
                 $('#results').html('<p class="message-text">No books found.</p>');
                 return;
               }
 
-              const results = data.items.map(item => {
-                const volumeInfo = item.volumeInfo;
-                const bookData = {
-                  id: item.id,
-                  title: volumeInfo.title,
-                  author: volumeInfo.authors ? volumeInfo.authors.join(', ') : 'Unknown',
-                  cover: volumeInfo.imageLinks ? volumeInfo.imageLinks.thumbnail : '',
-                  summary: volumeInfo.description || 'No description available.',
-                  isbn: volumeInfo.industryIdentifiers ?
-                    volumeInfo.industryIdentifiers.find(id => id.type === 'ISBN_13')?.identifier ||
-                    volumeInfo.industryIdentifiers[0]?.identifier :
-                    'No ISBN available',
-                  infoLink: volumeInfo.infoLink
-                };
-                // Store book data with ID as key
-                bookDataStore[item.id] = bookData;
+              const results = data.docs.map(doc => {
+                // Construct cover URL from cover_i if available
+                const coverUrl = doc.cover_i
+                  ? `https://covers.openlibrary.org/b/id/${doc.cover_i}-M.jpg`
+                  : '';
 
-                return `<button class='book-button' data-book-id="${item.id}">
+                // Get first ISBN_13 or fall back to first ISBN
+                const isbn = doc.isbn && doc.isbn.length > 0
+                  ? (doc.isbn.find(i => i.length === 13) || doc.isbn[0])
+                  : 'No ISBN available';
+
+                // Extract work ID from key (format: /works/OL82563W)
+                const workId = doc.key ? doc.key.split('/').pop() : doc.key;
+
+                const bookData = {
+                  id: workId || doc.key,
+                  title: doc.title || 'Unknown Title',
+                  author: doc.author_name ? doc.author_name.join(', ') : 'Unknown',
+                  cover: coverUrl,
+                  summary: doc.first_sentence ? doc.first_sentence.join(' ') : 'No description available.',
+                  isbn: isbn,
+                  infoLink: `https://openlibrary.org${doc.key}`
+                };
+
+                // Store book data with ID as key
+                bookDataStore[bookData.id] = bookData;
+
+                return `<button class='book-button' data-book-id="${bookData.id}">
                   ${bookData.title} by ${bookData.author}
                 </button>`;
               }).join('');
               $('#results').html(results);
             })
             .fail(function (xhr, status, error) {
-              console.error('Google Books API error:', error);
+              console.error('Open Library API error:', error);
               $('#results').html('<p class="error-text">Error searching for books. Please try again.</p>');
             });
         } else {
@@ -125,16 +135,16 @@
         }
       });
 
-      /* 
-        This script listens for click events on elements with the class 'book-result'.
-        When a 'book-result' element is clicked, it retrieves the 'id' data attribute of the clicked element.
+      /*
+        This script listens for click events on elements with the class 'book-button'.
+        When a 'book-button' element is clicked, it retrieves the 'id' data attribute of the clicked element.
         The 'id' attribute is then stored in the shared state of the Power-Up using the 'set' method.
         Finally, the popup is closed.
       */
       $(document).on('click', '.book-button', function () {
         const bookId = $(this).data('book-id');
         const bookData = bookDataStore[bookId];
-        // remove previous attachments that start with http://books.google.com/books
+        // remove previous attachments that start with https://openlibrary.org
         // ... doesn't seem to have this functionality. would have to use the rest api
         // add new attachments
         t.attach({ url: bookData.infoLink, name: bookData.title + ' -- by: ' + bookData.author });


### PR DESCRIPTION
Google Books API has stopped returning results for generic text searches, requiring field-specific operators (intitle:, inauthor:, etc.) which doesn't support fuzzy search needed for card names that may mix title/author or contain typos.

Changes:
- Replace Google Books API endpoint with Open Library API
- Update search response parsing for Open Library data structure
- Map Open Library cover_i to cover URL format
- Remove API key requirement (Open Library is free/open)
- Update documentation references from Google Books to Open Library
- Remove API key security validation section from testing guide
- Update package.json keywords

Open Library API benefits:
- Generic fuzzy search works without special operators
- No API key required
- Free and open source
- Good coverage of book metadata